### PR TITLE
Add GeL case flags field

### DIFF
--- a/tables/NGStest
+++ b/tables/NGStest
@@ -1,10 +1,13 @@
 USE [mokadata]
 GO
-/****** Object:  Table [dbo].[NGSTest]    Script Date: 04/12/2019 15:27:59 ******/
+
+/****** Object:  Table [dbo].[NGSTest]    Script Date: 12/12/2019 15:11:22 ******/
 SET ANSI_NULLS ON
 GO
+
 SET QUOTED_IDENTIFIER ON
 GO
+
 CREATE TABLE [dbo].[NGSTest](
 	[NGSTestID] [int] IDENTITY(1,1) NOT NULL,
 	[InternalPatientID] [int] NOT NULL,
@@ -27,12 +30,12 @@ CREATE TABLE [dbo].[NGSTest](
 	[Check4ID] [int] NULL,
 	[Check4Date] [datetime] NULL,
 	[BookingAuthorisedDate] [datetime] NULL,
-	[BookingAuthorisedByID] [int] NOT NULL CONSTRAINT [DF_NGSTest_BookingAuthorisedByID]  DEFAULT ((0)),
-	[Service] [bit] NOT NULL CONSTRAINT [DF_NGSTest_Service]  DEFAULT ((-1)),
+	[BookingAuthorisedByID] [int] NOT NULL,
+	[Service] [bit] NOT NULL,
 	[CostCentre] [int] NULL,
 	[Department] [int] NULL,
-	[Selection] [bit] NULL CONSTRAINT [DF_NGSTest_Selection]  DEFAULT ((0)),
-	[Priority] [bit] NULL CONSTRAINT [DF_NGSTest_Priority]  DEFAULT ((0)),
+	[Selection] [bit] NULL,
+	[Priority] [bit] NULL,
 	[WESBatch] [int] NULL,
 	[ResultComment] [ntext] NULL,
 	[ResultCode] [int] NULL,
@@ -43,9 +46,29 @@ CREATE TABLE [dbo].[NGSTest](
 	[IRID] [nvarchar](50) NULL,
 	[GWWorksheet] [int] NULL,
 	[MDTdate] [datetime] NULL,
-	[BlockAutomatedReporting] [smallint] NOT NULL CONSTRAINT [DF_NGSTest_BlockAutomatedReporting]  DEFAULT ((0)),
+	[BlockAutomatedReporting] [smallint] NOT NULL,
+	[GeL_case_flags] [nvarchar](max) NULL,
  CONSTRAINT [PK_NGSTest] PRIMARY KEY CLUSTERED 
 (
 	[NGSTestID] ASC
-)WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+
+GO
+
+ALTER TABLE [dbo].[NGSTest] ADD  CONSTRAINT [DF_NGSTest_BookingAuthorisedByID]  DEFAULT ((0)) FOR [BookingAuthorisedByID]
+GO
+
+ALTER TABLE [dbo].[NGSTest] ADD  CONSTRAINT [DF_NGSTest_Service]  DEFAULT ((-1)) FOR [Service]
+GO
+
+ALTER TABLE [dbo].[NGSTest] ADD  CONSTRAINT [DF_NGSTest_Selection]  DEFAULT ((0)) FOR [Selection]
+GO
+
+ALTER TABLE [dbo].[NGSTest] ADD  CONSTRAINT [DF_NGSTest_Priority]  DEFAULT ((0)) FOR [Priority]
+GO
+
+ALTER TABLE [dbo].[NGSTest] ADD  CONSTRAINT [DF_NGSTest_BlockAutomatedReporting]  DEFAULT ((0)) FOR [BlockAutomatedReporting]
+GO
+
+


### PR DESCRIPTION
GeL can add flags to cases to alert to important information such as suspected UPD, low quality calls etc (full description in GeL rare disease results guide).

Add field to Moka NGSTest to record these flags

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/moka-fe/605)
<!-- Reviewable:end -->
