### PR TITLE
3.129

### DIFF
--- a/forms/87010 ExomePatients
+++ b/forms/87010 ExomePatients
@@ -80,7 +80,7 @@ Private Sub SubmitNGSTest_Click()
   
   ' Send success message and Close Form
   MsgBox "Exome test request submitted.", vbInformation, "Test Request Submitted"
-  DoCmd.close
+  DoCmd.Close
   Exit Sub ' Note: Exit Sub here otherwise the default error code 0 triggers the error handler
 
 Err_NGSTestError:
@@ -383,7 +383,7 @@ Private Sub UpdateGeneCount(PanelBox As listbox)
     MsgBox "Warning: No gene panel box found."
     Err.Raise 1000, "No PanelBox Found", "GenePanelListBox names incorrect."
   End If
-  rst.close
+  rst.Close
 End Sub
 
 
@@ -445,7 +445,7 @@ Private Function IsInMoka(PatientID As String)
     Else
         IsInMoka = True
     End If
-    moka.close
+    moka.Close
 End Function
 
 Private Sub InsertGWPatientIntoMoka(PatientID As String)
@@ -484,7 +484,7 @@ Private Sub InsertGWPatientIntoMoka(PatientID As String)
       strGenderSQL = "SELECT GenderShort from gw_GenderTable WHERE GenderID = " & gwks!GenderID
       gwksg.Open strGenderSQL, CurrentProject.Connection, adOpenKeyset
       gwks_gender = gwksg!GenderShort
-      gwksg.close
+      gwksg.Close
     End If
     
     ' Insert Patient into Moka and log in patient log.
@@ -496,7 +496,7 @@ Private Sub InsertGWPatientIntoMoka(PatientID As String)
     DoCmd.RunSQL strAddPatientSQL
     PatientLogger PatientID, "Patients: Patient added to Moka."
     DoCmd.SetWarnings True
-    gwks.close
+    gwks.Close
 
 End Sub
 
@@ -638,7 +638,7 @@ Private Function CreateNGSTest(PRU As String, PrimaryPanelID As String, Secondar
     .update ' Save NGSTest Record
     .Bookmark = .LastModified
     strNGSTestID = !NGSTestID ' Save new NGSTestID to variable
-    .close
+    .Close
   End With
 
   ' Write NGS test creation Patient Log
@@ -671,7 +671,7 @@ Private Function PRUToInternalPatientID(PRU As String)
   Set rstPatientID = New ADODB.Recordset
   rstPatientID.Open strPIDquery, CurrentProject.Connection, adOpenKeyset
   PRUToInternalPatientID = rstPatientID!InternalPatientID
-  rstPatientID.close
+  rstPatientID.Close
   
 End Function
 
@@ -891,7 +891,7 @@ If Not rsGWDNAs.EOF Then
     DoCmd.SetWarnings True
     rsGWDNAs.MoveNext
   Wend
-rsGWDNAs.close
+rsGWDNAs.Close
 End If
 
 
@@ -914,8 +914,8 @@ If rsActiveDNAs.RecordCount = 0 Then
 
     ' Write DNA activation to PatientLog
     PatientLogger PRU, "DNA: Active status changed for DNA number [" & rsNewestDNA!DNAID & "]"
-    rsActiveDNAs.close
-    rsNewestDNA.close
+    rsActiveDNAs.Close
+    rsNewestDNA.Close
 End If
 
 End Sub
@@ -957,7 +957,7 @@ End Sub
 
 Private Sub btnClose_Click()
   'Close Form (X)
-  DoCmd.close
+  DoCmd.Close
 End Sub
 
 Private Sub btnFindPatient_Click()
@@ -1019,7 +1019,7 @@ Private Sub btnAddPatient_Click()
     ' Add patient to the Patient details to PatientList ListBox for testing
     ' Format: strPatientName,strRelationship,strStatus,strPatientID,strRelationshipItemID,strStatusItemID
     ' Example: Wesley Test BINFX TESTING,Proband,Affected,451880:01,3302,3337
-    PatientListInput = Me.PatientCombo.Column(1) & "," & Me.RelationshipCombo.Column(1) & "," & Me.AffectedCombo.Column(1) & _
+    PatientListInput = "'" & Me.PatientCombo.Column(1) & "'" & "," & Me.RelationshipCombo.Column(1) & "," & Me.AffectedCombo.Column(1) & _
         "," & Me.PatientCombo.Column(0) & "," & Me.RelationshipCombo.Column(0) & "," & Me.AffectedCombo.Column(0)
     Me.PatientList.AddItem PatientListInput, 0
 End Sub

--- a/forms/87020 ExomeLab
+++ b/forms/87020 ExomeLab
@@ -32,7 +32,7 @@ Dim unsel As String
     DoCmd.SetWarnings True
     'Save record
     'DoCmd.DoMenuItem acFormBar, acRecordsMenu, 5, , acMenuVer70
-            
+
 End Function
 
 Private Sub Form_Current()
@@ -972,28 +972,28 @@ Else
                                                 "  LEFT JOIN ngstest ON ngstest.ngstestid = ngsanalysis.ngstestid " & _
                                                 " WHERE ngstest.ngstestid = " & rsStatus!NGSTestID & " ) "
                                     rsTestGroup.Open sqlGroupedNGSTests, CurrentProject.Connection, adOpenKeyset
-                                    
+
                                      If (rsTestGroup.RecordCount > 1) And MsgBox("NGSTestID " & rsStatus!NGSTestID & " is in a group of " & rsTestGroup.RecordCount & " tests. You are about to update the status of all tests in this group. Continue?", vbYesNo Or vbExclamation, "Update all tests in referral group?") = vbNo Then
                                          Cancel = True
                                          Exit Sub
                                      End If
-                                     
+
                                      ' Iterate over all NGSTests linked by NGSAnalysis and update their status to complete or test failed
                                      ' This is done to meet the requirement that any NGStest closed or failed via the WES dashboard also
                                      '   closes or fails tests in the same NGS analysis.
                                      With rsTestGroup
                                        While Not .EOF
-                                       
+
                                          strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   WHERE NGSTest.NGSTestID = " & rsTestGroup!NGSTestID
                                          strUpd8Patient = "UPDATE Patients SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & " WHERE Patients.InternalPatientID = " & rsTestGroup!InternalPatientID
-                                         
+
                                          ' update patient log
                                          strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
                                          strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
                                          strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
                                          'update NGSlogmemo
                                          strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(rsTestGroup!InternalPatientID) + ", 1, " + CStr(rsTestGroup!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
-                                        
+
                                          DoCmd.SetWarnings False
                                          DoCmd.RunSQL strUpd8Status
                                          DoCmd.RunSQL strUpd8Patient
@@ -1005,7 +1005,7 @@ Else
                                          .MoveNext
                                        Wend
                                      End With
-                                     
+
                                      ' Clear the rsTestGroup recordset for reuse in future loops
                                      rsTestGroup.Close
                                      Set rsTestGroup = Nothing
@@ -1016,16 +1016,16 @@ Else
                                     A = MsgBox("Approver ID is required to batch update test status to " & Me!cmb_StatusUpdate.Column(1), vbOKOnly Or vbExclamation, "Approver ID required")
                                     Me.Cmb_Approver.SetFocus
                                     Exit Sub
-                                    
+
                                 End If
-                                
+
                             Else ' just update test status and status log
                                 strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " WHERE NGSTest.NGSTestID = " & rsStatus!NGSTestID
                                 ' update patient log
                                 strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsStatus!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsStatus!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
                                 'update NGSlogmemo
                                 strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(rsStatus!InternalPatientID) + ", 1, " + CStr(rsStatus!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
-                               
+
                                 DoCmd.SetWarnings False
                                 DoCmd.RunSQL strUpd8Status
                                 DoCmd.RunSQL strLogSQL2
@@ -1041,7 +1041,7 @@ Else
                     Else
                         .MoveNext
                     End If
-                    
+
                     msg6 = MsgBox("The status of " & selTotal & " WES tests has been updated to " + Me.cmb_StatusUpdate.Column(1), vbOKOnly, "Status update Sucessful")
 
                     End If
@@ -1049,7 +1049,7 @@ Else
             End With
         End If
     End If
-    
+
 ' Refresh form, clear filter settings recount samples
 Call Unselect
 Form![s87020_ExomeLabList]![StatusID].Requery

--- a/forms/87020 ExomeLab
+++ b/forms/87020 ExomeLab
@@ -798,20 +798,6 @@ Else
 End If
 End Sub
 
-Private Function GetNGSTestsAndPatientsInAnalysis(NGSTestID As Integer) As Variant
-    ' Returns an array listing all NGS tests that share a group id (NGSAnalysis.NGSAnalysisGroupID) with the input NGSTestID
-    '    Data is returned as an array with ngstests in the first column. First test is accessed with myarray(0,0), second with myarray(0,1) etc.
-    Dim rsTestGroup As ADODB.Recordset
-    Dim Result(10) As Integer
-    Set rsTestGroup = New ADODB.Recordset
-    sqlGroupedNGSTests = "SELECT ngstestid, internalpatientid FROM ngsanalysis WHERE ngsanalysisgroupid = (" & _
-      "SELECT ngsanalysisgroupid FROM ngsanalysis " & _
-      "  LEFT JOIN ngstest ON ngstest.ngstestid = ngsanalysis.ngstestid " & _
-      " WHERE ngstest.ngstestid = " & NGSTestID & " ) "
-    rsTestGroup.Open sqlGroupedNGSTests, CurrentProject.Connection, adOpenKeyset
-    GetNGSTestsAndPatientsInAnalysis = rsTestGroup.GetRows()
-    rsTestGroup.Close
-End Function
 
 Private Sub btn_UpdateStatus_Click()
 Dim rsStatus As dao.Recordset
@@ -829,6 +815,7 @@ Dim strLogSQL As String
 Dim strLogAprov As String
 Dim strLogSQL2 As String
 Dim strLogMemo As String
+Dim rsTestGroup As ADODB.Recordset
 
 dt = Format(Now, "dd/mmm/yyyy Hh:Nn:ss")
 cmp = VBA.Environ("COMPUTERNAME")
@@ -973,39 +960,57 @@ Else
                                Me.Cmb_Approver.Visible = True
                               ' Check that an authoriser ID has been entered
                                 If Not IsNull(Cmb_Approver) Then
+                                     ' Iterate over all NGSTests linked by NGSAnalysis and update test status to complete or test failed.
+                                     ' This implements an in-house requirement for all NGSTests in an NGS analysis to be completed or failed
+                                     ' together via the WES dashboard. Therefore, this section make sure no tests in the same NGS analysis remain in progress incorrectly.
+                                     
+                                     ' Get an array of all ngstests with the same NGSAnalysis group ID as the current NGSTestID
+                                    Set rsTestGroup = New ADODB.Recordset
+                                    sqlGroupedNGSTests = "" & _
+                                      "SELECT ngstestid, internalpatientid FROM ngsanalysis WHERE ngsanalysisgroupid = (" & _
+                                                "SELECT ngsanalysisgroupid FROM ngsanalysis " & _
+                                                "  LEFT JOIN ngstest ON ngstest.ngstestid = ngsanalysis.ngstestid " & _
+                                                " WHERE ngstest.ngstestid = " & rsStatus!NGSTestID & " ) "
+                                    rsTestGroup.Open sqlGroupedNGSTests, CurrentProject.Connection, adOpenKeyset
                                     
-                                     ' Iterate over all NGSTests linked by NGSAnalysis and update test status to complete or test failed
-                                     allTestsInAnalysis = GetNGSTestsAndPatientsInAnalysis(rsStatus!NGSTestID)
-                                     allTestsCount = UBound(allTestsInAnalysis, 2) + 1
-                                     If (allTestsCount > 1) And MsgBox("NGSTestID " & rsStatus!NGSTestID & " is in a group of " & allTestsCount & " tests. You are about to update the status of all tests in this group. Continue?", vbYesNo Or vbExclamation, "Update all tests in referral group?") = vbNo Then
+                                     If (rsTestGroup.RecordCount > 1) And MsgBox("NGSTestID " & rsStatus!NGSTestID & " is in a group of " & rsTestGroup.RecordCount & " tests. You are about to update the status of all tests in this group. Continue?", vbYesNo Or vbExclamation, "Update all tests in referral group?") = vbNo Then
                                          Cancel = True
                                          Exit Sub
                                      End If
-                                    For i = 0 To UBound(allTestsInAnalysis, 2)
-                                      NGSTestID = allTestsInAnalysis(0, i)
-                                      InternalPatientID = allTestsInAnalysis(1, i)
-                                      strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   WHERE NGSTest.NGSTestID = " & NGSTestID
-                                      strUpd8Patient = "UPDATE Patients SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & " WHERE Patients.InternalPatientID = " & InternalPatientID
-                                      
-                                      ' update patient log
-                                      strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                      strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                      strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                      'update NGSlogmemo
-                                      strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(InternalPatientID) + ", 1, " + CStr(NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
                                      
-                                     Debug.Print strUpd8Status
+                                     ' Iterate over all NGSTests linked by NGSAnalysis and update their status to complete or test failed
+                                     ' This is done to meet the requirement that any NGStest closed or failed via the WES dashboard also
+                                     '   closes or fails tests in the same NGS analysis.
+                                     With rsTestGroup
+                                       While Not .EOF
+                                       
+                                         strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   WHERE NGSTest.NGSTestID = " & rsTestGroup!NGSTestID
+                                         strUpd8Patient = "UPDATE Patients SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & " WHERE Patients.InternalPatientID = " & rsTestGroup!InternalPatientID
+                                         
+                                         ' update patient log
+                                         strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                         strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                         strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                         'update NGSlogmemo
+                                         strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(rsTestGroup!InternalPatientID) + ", 1, " + CStr(rsTestGroup!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
+                                        
+                                         DoCmd.SetWarnings False
+                                         DoCmd.RunSQL strUpd8Status
+                                         DoCmd.RunSQL strUpd8Patient
+                                         DoCmd.RunSQL strLogSQL
+                                         DoCmd.RunSQL strLogAprov
+                                         DoCmd.RunSQL strLogSQL2
+                                         DoCmd.RunSQL strLogMemo
+                                         DoCmd.SetWarnings True
+                                         .MoveNext
+                                       Wend
+                                     End With
                                      
-                                      DoCmd.SetWarnings False
-                                      DoCmd.RunSQL strUpd8Status
-                                      DoCmd.RunSQL strUpd8Patient
-                                      DoCmd.RunSQL strLogSQL
-                                      DoCmd.RunSQL strLogAprov
-                                      DoCmd.RunSQL strLogSQL2
-                                      DoCmd.RunSQL strLogMemo
-                                      DoCmd.SetWarnings True
-    
-                                    Next i
+                                     ' Clear the rsTestGroup recordset for reuse in future loops
+                                     rsTestGroup.Close
+                                     Set rsTestGroup = Nothing
+
+                                    ' Go to the next NGSTest selected by the user on the WES dashboard
                                     .MoveNext
                                 Else
                                     A = MsgBox("Approver ID is required to batch update test status to " & Me!cmb_StatusUpdate.Column(1), vbOKOnly Or vbExclamation, "Approver ID required")
@@ -1072,6 +1077,7 @@ End Sub
 Private Sub btn_refresh_Click()
     Call update_referral
     Call update_display
+'Form!s87020_ExomeLabList.Requery
 End Sub
 
 Private Sub user_group_clear_Click()

--- a/forms/87020 ExomeLab
+++ b/forms/87020 ExomeLab
@@ -966,11 +966,14 @@ Else
 
                                      ' Get an array of all ngstests with the same NGSAnalysis group ID as the current NGSTestID
                                     Set rsTestGroup = New ADODB.Recordset
-                                    sqlGroupedNGSTests = "" & _
-                                      "SELECT ngstestid, internalpatientid FROM ngsanalysis WHERE ngsanalysisgroupid = (" & _
-                                                "SELECT ngsanalysisgroupid FROM ngsanalysis " & _
-                                                "  LEFT JOIN ngstest ON ngstest.ngstestid = ngsanalysis.ngstestid " & _
-                                                " WHERE ngstest.ngstestid = " & rsStatus!NGSTestID & " ) "
+                                    sqlGroupedNGSTests = "SELECT ngstestid, internalpatientid " & _
+                                                         "  FROM ngsanalysis                  " & _
+                                                         " WHERE ngsanalysisgroupid =         " & _
+                                                         "       (SELECT ngsanalysisgroupid   " & _
+                                                         "          FROM ngsanalysis          " & _
+                                                         "               LEFT JOIN ngstest    " & _
+                                                         "                      ON ngstest.ngstestid = ngsanalysis.ngstestid " & _
+                                                         "         WHERE ngstest.ngstestid = " & rsStatus!NGSTestID & " ) "
                                     rsTestGroup.Open sqlGroupedNGSTests, CurrentProject.Connection, adOpenKeyset
 
                                      If (rsTestGroup.RecordCount > 1) And MsgBox("NGSTestID " & rsStatus!NGSTestID & " is in a group of " & rsTestGroup.RecordCount & " tests. You are about to update the status of all tests in this group. Continue?", vbYesNo Or vbExclamation, "Update all tests in referral group?") = vbNo Then
@@ -984,15 +987,23 @@ Else
                                      With rsTestGroup
                                        While Not .EOF
 
-                                         strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   WHERE NGSTest.NGSTestID = " & rsTestGroup!NGSTestID
-                                         strUpd8Patient = "UPDATE Patients SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & " WHERE Patients.InternalPatientID = " & rsTestGroup!InternalPatientID
+                                         strUpd8Status = "UPDATE NGSTest " & _
+                                                         "   SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   " & _
+                                                         " WHERE NGSTest.NGSTestID = " & rsTestGroup!NGSTestID
+                                         strUpd8Patient = "UPDATE Patients " & _
+                                                          "   SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & _
+                                                          " WHERE Patients.InternalPatientID = " & rsTestGroup!InternalPatientID
 
                                          ' update patient log
-                                         strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                         strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                         strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                         strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) " & _
+                                                     "VALUES (" & rsTestGroup!InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                         strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) " & _
+                                                       "VALUES (" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                         strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) " & _
+                                                      "VALUES (" & rsTestGroup!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsTestGroup!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
                                          'update NGSlogmemo
-                                         strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(rsTestGroup!InternalPatientID) + ", 1, " + CStr(rsTestGroup!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
+                                         strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) " & _
+                                                      "VALUES (" + CStr(rsTestGroup!InternalPatientID) + ", 1, " + CStr(rsTestGroup!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
 
                                          DoCmd.SetWarnings False
                                          DoCmd.RunSQL strUpd8Status
@@ -1020,11 +1031,15 @@ Else
                                 End If
 
                             Else ' just update test status and status log
-                                strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " WHERE NGSTest.NGSTestID = " & rsStatus!NGSTestID
+                                strUpd8Status = "UPDATE NGSTest " & _
+                                                "   SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & _
+                                                " WHERE NGSTest.NGSTestID = " & rsStatus!NGSTestID
                                 ' update patient log
-                                strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsStatus!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsStatus!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) " & _
+                                             "VALUES (" & rsStatus!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsStatus!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
                                 'update NGSlogmemo
-                                strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(rsStatus!InternalPatientID) + ", 1, " + CStr(rsStatus!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
+                                strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) " & _
+                                             "VALUES (" + CStr(rsStatus!InternalPatientID) + ", 1, " + CStr(rsStatus!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
 
                                 DoCmd.SetWarnings False
                                 DoCmd.RunSQL strUpd8Status
@@ -1077,7 +1092,6 @@ End Sub
 Private Sub btn_refresh_Click()
     Call update_referral
     Call update_display
-'Form!s87020_ExomeLabList.Requery
 End Sub
 
 Private Sub user_group_clear_Click()

--- a/forms/87020 ExomeLab
+++ b/forms/87020 ExomeLab
@@ -963,7 +963,7 @@ Else
                                      ' Iterate over all NGSTests linked by NGSAnalysis and update test status to complete or test failed.
                                      ' This implements an in-house requirement for all NGSTests in an NGS analysis to be completed or failed
                                      ' together via the WES dashboard. Therefore, this section make sure no tests in the same NGS analysis remain in progress incorrectly.
-                                     
+
                                      ' Get an array of all ngstests with the same NGSAnalysis group ID as the current NGSTestID
                                     Set rsTestGroup = New ADODB.Recordset
                                     sqlGroupedNGSTests = "" & _

--- a/forms/87020 ExomeLab
+++ b/forms/87020 ExomeLab
@@ -798,6 +798,20 @@ Else
 End If
 End Sub
 
+Private Function GetNGSTestsAndPatientsInAnalysis(NGSTestID As Integer) As Variant
+    ' Returns an array listing all NGS tests that share a group id (NGSAnalysis.NGSAnalysisGroupID) with the input NGSTestID
+    '    Data is returned as an array with ngstests in the first column. First test is accessed with myarray(0,0), second with myarray(0,1) etc.
+    Dim rsTestGroup As ADODB.Recordset
+    Dim Result(10) As Integer
+    Set rsTestGroup = New ADODB.Recordset
+    sqlGroupedNGSTests = "SELECT ngstestid, internalpatientid FROM ngsanalysis WHERE ngsanalysisgroupid = (" & _
+      "SELECT ngsanalysisgroupid FROM ngsanalysis " & _
+      "  LEFT JOIN ngstest ON ngstest.ngstestid = ngsanalysis.ngstestid " & _
+      " WHERE ngstest.ngstestid = " & NGSTestID & " ) "
+    rsTestGroup.Open sqlGroupedNGSTests, CurrentProject.Connection, adOpenKeyset
+    GetNGSTestsAndPatientsInAnalysis = rsTestGroup.GetRows()
+    rsTestGroup.Close
+End Function
 
 Private Sub btn_UpdateStatus_Click()
 Dim rsStatus As dao.Recordset
@@ -958,29 +972,41 @@ Else
                             If (Me.cmb_StatusUpdate.Column(0) = 4 And rsStatus!StatusID = 1202218814) Or (Me.cmb_StatusUpdate.Column(0) = 1202218816 And rsStatus!StatusID = 1202218815) Then
                                Me.Cmb_Approver.Visible = True
                               ' Check that an authoriser ID has been entered
-                                If Not IsNull(Cmb_Approver) Then ' update test status to complete
-                                     strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   WHERE NGSTest.NGSTestID = " & rsStatus!NGSTestID
-                                     strUpd8Patient = "UPDATE Patients SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & " WHERE Patients.InternalPatientID = " & rsStatus!InternalPatientID
-                                     
-                                     ' update patient log
-                                     strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsStatus!InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                     strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsStatus!InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & rsStatus!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                     strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & rsStatus!InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & rsStatus!NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
-                                     'update NGSlogmemo
-                                     strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(rsStatus!InternalPatientID) + ", 1, " + CStr(rsStatus!NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
+                                If Not IsNull(Cmb_Approver) Then
                                     
-                                    Debug.Print strUpd8Status
-                                    
-                                     DoCmd.SetWarnings False
-                                     DoCmd.RunSQL strUpd8Status
-                                     DoCmd.RunSQL strUpd8Patient
-                                     DoCmd.RunSQL strLogSQL
-                                     DoCmd.RunSQL strLogAprov
-                                     DoCmd.RunSQL strLogSQL2
-                                     DoCmd.RunSQL strLogMemo
-                                     DoCmd.SetWarnings True
-                                     .MoveNext
+                                     ' Iterate over all NGSTests linked by NGSAnalysis and update test status to complete or test failed
+                                     allTestsInAnalysis = GetNGSTestsAndPatientsInAnalysis(rsStatus!NGSTestID)
+                                     allTestsCount = UBound(allTestsInAnalysis, 2) + 1
+                                     If (allTestsCount > 1) And MsgBox("NGSTestID " & rsStatus!NGSTestID & " is in a group of " & allTestsCount & " tests. You are about to update the status of all tests in this group. Continue?", vbYesNo Or vbExclamation, "Update all tests in referral group?") = vbNo Then
+                                         Cancel = True
+                                         Exit Sub
+                                     End If
+                                    For i = 0 To UBound(allTestsInAnalysis, 2)
+                                      NGSTestID = allTestsInAnalysis(0, i)
+                                      InternalPatientID = allTestsInAnalysis(1, i)
+                                      strUpd8Status = "UPDATE NGSTest SET StatusID = " & Me!cmb_StatusUpdate.Column(0) & " , Check4ID = " & Me!Cmb_Approver & " , Check4Date =  #" + dt + "#   WHERE NGSTest.NGSTestID = " & NGSTestID
+                                      strUpd8Patient = "UPDATE Patients SET s_StatusOverall = " & Me!cmb_StatusUpdate.Column(0) & " WHERE Patients.InternalPatientID = " & InternalPatientID
+                                      
+                                      ' update patient log
+                                      strLogSQL = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & InternalPatientID & ", 'Patient: Status changed to " + Me!cmb_StatusUpdate.Column(1) + ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                      strLogAprov = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & InternalPatientID & ", 'NGS WES test: Report approved by " & Me!Cmb_Approver.Column(0) & " for test requested " & rsStatus!DateRequested & " NGS testID " & NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                      strLogSQL2 = "INSERT INTO PatientLog(InternalPatientID, LogEntry, [Date], Login, PCName) VALUES(" & InternalPatientID & ", 'NGS WES test: Status updated to " + Me!cmb_StatusUpdate.Column(1) + " for test requested " & rsStatus!DateRequested & " NGS testID " & NGSTestID & ". ',#" + dt + "#,'" + usr + "','" + cmp + "')"
+                                      'update NGSlogmemo
+                                      strLogMemo = "INSERT INTO NGSLogMemo(InternalPatientID, Type, LinkID, LogMemoEntry, [Date], Login, PCName) VALUES(" + CStr(InternalPatientID) + ", 1, " + CStr(NGSTestID) + ",'NGS WES test status updated to: " + Me!cmb_StatusUpdate.Column(1) + "' ,#" + dt + "#,'" + usr + "','" + cn + "')"
                                      
+                                     Debug.Print strUpd8Status
+                                     
+                                      DoCmd.SetWarnings False
+                                      DoCmd.RunSQL strUpd8Status
+                                      DoCmd.RunSQL strUpd8Patient
+                                      DoCmd.RunSQL strLogSQL
+                                      DoCmd.RunSQL strLogAprov
+                                      DoCmd.RunSQL strLogSQL2
+                                      DoCmd.RunSQL strLogMemo
+                                      DoCmd.SetWarnings True
+    
+                                    Next i
+                                    .MoveNext
                                 Else
                                     A = MsgBox("Approver ID is required to batch update test status to " & Me!cmb_StatusUpdate.Column(1), vbOKOnly Or vbExclamation, "Approver ID required")
                                     Me.Cmb_Approver.SetFocus
@@ -1044,7 +1070,8 @@ ErrHandler:
 End Sub
 
 Private Sub btn_refresh_Click()
-Form!s87020_ExomeLabList.Requery
+    Call update_referral
+    Call update_display
 End Sub
 
 Private Sub user_group_clear_Click()

--- a/forms/s02_NGSTest
+++ b/forms/s02_NGSTest
@@ -69,7 +69,7 @@ End Sub
 Private Sub ReferralID_DblClick(Cancel As Integer)
 ' define variables
 Dim rsCopyNGSTest As ADODB.Recordset
-Dim sql As String
+Dim Sql As String
 Dim date_now As String
 Dim computername As String
 Dim UserName As String
@@ -85,17 +85,17 @@ msgb = MsgBox("You are about to fail NGSest ID " & Me.NGSTestID & " and create a
 If msgb = vbYes Then
 '' Create a new NGSTest record using fields from the failed test
 'build sql to create a copy of all the required fields
-sql = "INSERT INTO ngstest (internalpatientid, referralid, ngspanelid, ngspanelid_b, ngspanelid_c, statusid, daterequested, bookby, resultbuild, bookingauthoriseddate, bookingauthorisedbyid, service, costcentre, department, priority) " & _
+Sql = "INSERT INTO ngstest (internalpatientid, referralid, ngspanelid, ngspanelid_b, ngspanelid_c, statusid, daterequested, bookby, resultbuild, bookingauthoriseddate, bookingauthorisedbyid, service, costcentre, department, priority) " & _
       "SELECT internalpatientid, referralid, ngspanelid, ngspanelid_b, ngspanelid_c, 1202218803, daterequested, bookby, resultbuild, bookingauthoriseddate, bookingauthorisedbyid, service, costcentre, department, priority " & _
         "FROM ngstest " & _
        "WHERE ngstestid =" & Me.NGSTestID
        
 Debug.Print "inserting new NGStest"
-Debug.Print sql
+Debug.Print Sql
 ' create new recordset - A recordset is used over DoCmd as we need to return the key of newly inserted row.
 Set rsCopyNGSTest = New ADODB.Recordset
 ' run the sql to copy test
-rsCopyNGSTest.Open sql, CurrentProject.Connection
+rsCopyNGSTest.Open Sql, CurrentProject.Connection
 'Get ID of new entry
 rsCopyNGSTest.Open "SELECT @@identity", CurrentProject.Connection, adOpenKeyset
 NewTestID = rsCopyNGSTest.Fields(0).Value
@@ -103,64 +103,78 @@ Debug.Print "Newtestid = " & NewTestID
 Set rsCopyNGSTest = Nothing
 
 '' copy all ngstest files, adding a prefix to description to make it clear copied from prev test
-sql = "INSERT INTO ngstestfile(ngstestid,description,ngstestfile,dateadded,vcf_filter_import) " & _
+Sql = "INSERT INTO ngstestfile(ngstestid,description,ngstestfile,dateadded,vcf_filter_import) " & _
       "SELECT " & NewTestID & ",'copy_from_NGSTest'+'" & Me.NGSTestID & "'+'_'+description, ngstestfile, dateadded, vcf_filter_import " & _
         "FROM ngstestfile " & _
        "WHERE ngstestid = " & Me.NGSTestID
 Debug.Print "copying NGSTestfiles"
-Debug.Print sql
+Debug.Print Sql
 ' turn off warnings so doesn't warn about appending rows
 DoCmd.SetWarnings False
-DoCmd.RunSQL sql
+DoCmd.RunSQL Sql
 DoCmd.SetWarnings True
 
 '' copy panels in NGSTestPanelSelection
-sql = "INSERT INTO ngstestpanelselection(ngstestid, selectiontype, selectionid, analysisab) " & _
+Sql = "INSERT INTO ngstestpanelselection(ngstestid, selectiontype, selectionid, analysisab) " & _
       "SELECT " & NewTestID & ", selectiontype, selectionid, analysisab " & _
         "FROM ngstestpanelselection " & _
        "WHERE ngstestid = " & Me.NGSTestID
 Debug.Print "copying panels"
-Debug.Print sql
+Debug.Print Sql
 ' turn off warnings so doesn't warn about appending rows
 DoCmd.SetWarnings False
-DoCmd.RunSQL sql
+DoCmd.RunSQL Sql
 DoCmd.SetWarnings True
 
 '' update patient log to say new test copied from a failed test
 LogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
-sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
+Sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
       "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + LogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 Debug.Print "updating patient log with copying NGSTestfiles"
 Debug.Print LogEntry
-Debug.Print sql
+Debug.Print Sql
 ' turn off warnings so doesn't warn about appending rows
 DoCmd.SetWarnings False
-DoCmd.RunSQL sql
+DoCmd.RunSQL Sql
+DoCmd.SetWarnings True
+
+' Update the NGSAnalysis for the failed test with the new test ID
+sqlAnalysis = "UPDATE NGSAnalysis Set NGSTestID = " & NewTestID & " WHERE NGSTestID = " & NGSTestID
+DoCmd.SetWarnings False
+DoCmd.RunSQL sqlAnalysis
+DoCmd.SetWarnings True
+' Update patient log to say that NGS analysis ID has been updated
+LogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
+Sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
+      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + LogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
+strAnalysisLog = "NGS: An NGSAnalysisID has been updated, replacing NGSTest " & NGSTestID & " with " & NewTestID
+DoCmd.SetWarnings False
+DoCmd.RunSQL Sql
 DoCmd.SetWarnings True
 
 '' Deactivate failed test
 ' set status = 1202218816 (test failed)
 
-sql = "UPDATE ngstest " & _
+Sql = "UPDATE ngstest " & _
          "SET statusid = 1202218816 " & _
        "WHERE NGSTestID = " & Me.NGSTestID
 Debug.Print "setting status to test failed"
-Debug.Print sql
+Debug.Print Sql
 ' turn off warnings so doesn't warn about appending rows
 DoCmd.SetWarnings False
-DoCmd.RunSQL sql
+DoCmd.RunSQL Sql
 DoCmd.SetWarnings True
 
 '' update patient log to say test status set to failed
 LogEntry = "NGS: Status changed to ""test failed"" for NGSTestID" & Me.NGSTestID
-sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
+Sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
       "VALUES (" + CStr(Me![InternalPatientID]) + ",'" + LogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 Debug.Print "updating patient log to record setting test status to test failed"
 Debug.Print LogEntry
-Debug.Print sql
+Debug.Print Sql
 ' turn off warnings so doesn't warn about appending rows
 DoCmd.SetWarnings False
-DoCmd.RunSQL sql
+DoCmd.RunSQL Sql
 DoCmd.SetWarnings True
 
 ' refresh form to reflect changes applied above

--- a/forms/s02_NGSTest
+++ b/forms/s02_NGSTest
@@ -67,7 +67,8 @@ Private Sub DNA_Enter()
 End Sub
 
 Private Sub ReferralID_DblClick(Cancel As Integer)
-' define variables
+' Fail and NGSTest and create a new test with the same details. This function is activated by double-clicking the referall column in the NGSTest tab of
+'    the patient details page.
 Dim rsCopyNGSTest As ADODB.Recordset
 Dim Sql As String
 Dim date_now As String
@@ -80,18 +81,15 @@ computername = VBA.Environ("COMPUTERNAME")
 UserName = VBA.Environ("USERNAME")
 date_now = Format(Now, "dd/mmm/yyyy Hh:Nn:ss")
 
-' open prompt to confirm test is to be failed and new test created from copy of this testID
+' Open prompt to confirm test is to be failed and new test created from copy of this testID
 msgb = MsgBox("You are about to fail NGSest ID " & Me.NGSTestID & " and create a new test request based on this test." + vbNewLine + "Do you wish to continue?", vbYesNo, "Fail & copy test?")
 If msgb = vbYes Then
-'' Create a new NGSTest record using fields from the failed test
-'build sql to create a copy of all the required fields
+' Create a new NGSTest record using fields from the failed test
+'    build sql to create a copy of all the required fields
 Sql = "INSERT INTO ngstest (internalpatientid, referralid, ngspanelid, ngspanelid_b, ngspanelid_c, statusid, daterequested, bookby, resultbuild, bookingauthoriseddate, bookingauthorisedbyid, service, costcentre, department, priority) " & _
       "SELECT internalpatientid, referralid, ngspanelid, ngspanelid_b, ngspanelid_c, 1202218803, daterequested, bookby, resultbuild, bookingauthoriseddate, bookingauthorisedbyid, service, costcentre, department, priority " & _
         "FROM ngstest " & _
        "WHERE ngstestid =" & Me.NGSTestID
-       
-Debug.Print "inserting new NGStest"
-Debug.Print Sql
 ' create new recordset - A recordset is used over DoCmd as we need to return the key of newly inserted row.
 Set rsCopyNGSTest = New ADODB.Recordset
 ' run the sql to copy test
@@ -99,85 +97,58 @@ rsCopyNGSTest.Open Sql, CurrentProject.Connection
 'Get ID of new entry
 rsCopyNGSTest.Open "SELECT @@identity", CurrentProject.Connection, adOpenKeyset
 NewTestID = rsCopyNGSTest.Fields(0).Value
-Debug.Print "Newtestid = " & NewTestID
 Set rsCopyNGSTest = Nothing
 
-'' copy all ngstest files, adding a prefix to description to make it clear copied from prev test
-Sql = "INSERT INTO ngstestfile(ngstestid,description,ngstestfile,dateadded,vcf_filter_import) " & _
+' Build all SQL queries for procedures required to fail and copy NGS test:
+
+'   Copy all ngstest files, adding a prefix to description to make it clear copied from prev test
+copyNGSTestSQL = "INSERT INTO ngstestfile(ngstestid,description,ngstestfile,dateadded,vcf_filter_import) " & _
       "SELECT " & NewTestID & ",'copy_from_NGSTest'+'" & Me.NGSTestID & "'+'_'+description, ngstestfile, dateadded, vcf_filter_import " & _
         "FROM ngstestfile " & _
        "WHERE ngstestid = " & Me.NGSTestID
-Debug.Print "copying NGSTestfiles"
-Debug.Print Sql
-' turn off warnings so doesn't warn about appending rows
-DoCmd.SetWarnings False
-DoCmd.RunSQL Sql
-DoCmd.SetWarnings True
 
-'' copy panels in NGSTestPanelSelection
-Sql = "INSERT INTO ngstestpanelselection(ngstestid, selectiontype, selectionid, analysisab) " & _
+'   Copy panels in NGSTestPanelSelection
+copyNGSTestPanelSQL = "INSERT INTO ngstestpanelselection(ngstestid, selectiontype, selectionid, analysisab) " & _
       "SELECT " & NewTestID & ", selectiontype, selectionid, analysisab " & _
         "FROM ngstestpanelselection " & _
        "WHERE ngstestid = " & Me.NGSTestID
-Debug.Print "copying panels"
-Debug.Print Sql
-' turn off warnings so doesn't warn about appending rows
-DoCmd.SetWarnings False
-DoCmd.RunSQL Sql
-DoCmd.SetWarnings True
 
-'' update patient log to say new test copied from a failed test
-LogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
-Sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
-      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + LogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
-Debug.Print "updating patient log with copying NGSTestfiles"
-Debug.Print LogEntry
-Debug.Print Sql
-' turn off warnings so doesn't warn about appending rows
-DoCmd.SetWarnings False
-DoCmd.RunSQL Sql
-DoCmd.SetWarnings True
+'   Update patient log to say new test copied from a failed test
+copyNGSTestLogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
+copyNGSTestPatientLogEntrySQL = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
+      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + copyNGSTestLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 
-' Update the NGSAnalysis for the failed test with the new test ID
-sqlAnalysis = "UPDATE NGSAnalysis Set NGSTestID = " & NewTestID & " WHERE NGSTestID = " & NGSTestID
-DoCmd.SetWarnings False
-DoCmd.RunSQL sqlAnalysis
-DoCmd.SetWarnings True
-' Update patient log to say that NGS analysis ID has been updated
-LogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
-Sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
-      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + LogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
-strAnalysisLog = "NGS: An NGSAnalysisID has been updated, replacing NGSTest " & NGSTestID & " with " & NewTestID
-DoCmd.SetWarnings False
-DoCmd.RunSQL Sql
-DoCmd.SetWarnings True
+'   Update the NGSAnalysis for the failed test with the new test ID
+updateNGSAnalysisSQL = "UPDATE NGSAnalysis Set NGSTestID = " & NewTestID & " WHERE NGSTestID = " & NGSTestID
 
-'' Deactivate failed test
-' set status = 1202218816 (test failed)
+'   Update patient log to say that NGS analysis ID has been updated
+updateNGSAnalysisLogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
+updateNGSAnalysisLogEntrySQL = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
+      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + updateNGSAnalysisLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 
-Sql = "UPDATE ngstest " & _
+'  Deactivate failed test by settings NGSTest status to 'Test Failed' (1202218816)
+failNGSTestSQL = "UPDATE ngstest " & _
          "SET statusid = 1202218816 " & _
        "WHERE NGSTestID = " & Me.NGSTestID
-Debug.Print "setting status to test failed"
-Debug.Print Sql
-' turn off warnings so doesn't warn about appending rows
+
+'  Update patient log to say test status set to failed
+failNGSTestLogEntry = "NGS: Status changed to ""test failed"" for NGSTestID" & Me.NGSTestID
+failNGSTestLogEntrySQL = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
+      "VALUES (" + CStr(Me![InternalPatientID]) + ",'" + failNGSTestLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
+
+' Run SQL commands
+'   Turn off warnings so doesn't warn about appending rows
 DoCmd.SetWarnings False
-DoCmd.RunSQL Sql
+DoCmd.RunSQL copyNGSTestSQL
+DoCmd.RunSQL copyNGSTestPanelSQL
+DoCmd.RunSQL copyNGSTestPatientLogEntrySQL
+DoCmd.RunSQL updateNGSAnalysisSQL
+DoCmd.RunSQL updateNGSAnalysisLogEntrySQL
+DoCmd.RunSQL failNGSTestSQL
+DoCmd.RunSQL failNGSTestLogEntrySQL
 DoCmd.SetWarnings True
 
-'' update patient log to say test status set to failed
-LogEntry = "NGS: Status changed to ""test failed"" for NGSTestID" & Me.NGSTestID
-Sql = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
-      "VALUES (" + CStr(Me![InternalPatientID]) + ",'" + LogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
-Debug.Print "updating patient log to record setting test status to test failed"
-Debug.Print LogEntry
-Debug.Print Sql
-' turn off warnings so doesn't warn about appending rows
-DoCmd.SetWarnings False
-DoCmd.RunSQL Sql
-DoCmd.SetWarnings True
-
-' refresh form to reflect changes applied above
+' Refresh form to reflect changes applied above
 Me.Requery
 
 End If

--- a/forms/s02_NGSTest
+++ b/forms/s02_NGSTest
@@ -67,7 +67,7 @@ Private Sub DNA_Enter()
 End Sub
 
 Private Sub ReferralID_DblClick(Cancel As Integer)
-' Fail and NGSTest and create a new test with the same details. This function is activated by double-clicking the referall column in the NGSTest tab of
+' Fail NGSTest and create a new test with the same details. This function is activated by double-clicking the referall column in the NGSTest tab of
 '    the patient details page.
 Dim rsCopyNGSTest As ADODB.Recordset
 Dim Sql As String
@@ -103,38 +103,40 @@ Set rsCopyNGSTest = Nothing
 
 '   Copy all ngstest files, adding a prefix to description to make it clear copied from prev test
 copyNGSTestSQL = "INSERT INTO ngstestfile(ngstestid,description,ngstestfile,dateadded,vcf_filter_import) " & _
-      "SELECT " & NewTestID & ",'copy_from_NGSTest'+'" & Me.NGSTestID & "'+'_'+description, ngstestfile, dateadded, vcf_filter_import " & _
-        "FROM ngstestfile " & _
-       "WHERE ngstestid = " & Me.NGSTestID
+                 "SELECT " & NewTestID & ",'copy_from_NGSTest'+'" & Me.NGSTestID & "'+'_'+description, ngstestfile, dateadded, vcf_filter_import " & _
+                 "  FROM ngstestfile " & _
+                 " WHERE ngstestid = " & Me.NGSTestID
 
 '   Copy panels in NGSTestPanelSelection
 copyNGSTestPanelSQL = "INSERT INTO ngstestpanelselection(ngstestid, selectiontype, selectionid, analysisab) " & _
-      "SELECT " & NewTestID & ", selectiontype, selectionid, analysisab " & _
-        "FROM ngstestpanelselection " & _
-       "WHERE ngstestid = " & Me.NGSTestID
+                      "SELECT " & NewTestID & ", selectiontype, selectionid, analysisab " & _
+                      "  FROM ngstestpanelselection " & _
+                      " WHERE ngstestid = " & Me.NGSTestID
 
 '   Update patient log to say new test copied from a failed test
 copyNGSTestLogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
 copyNGSTestPatientLogEntrySQL = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
-      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + copyNGSTestLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
+                                "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + copyNGSTestLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 
 '   Update the NGSAnalysis for the failed test with the new test ID
-updateNGSAnalysisSQL = "UPDATE NGSAnalysis Set NGSTestID = " & NewTestID & " WHERE NGSTestID = " & NGSTestID
+updateNGSAnalysisSQL = "UPDATE NGSAnalysis " & _
+                       "   SET NGSTestID = " & NewTestID & _
+                       " WHERE NGSTestID = " & NGSTestID
 
 '   Update patient log to say that NGS analysis ID has been updated
 updateNGSAnalysisLogEntry = "NGS: New test request (NGSTestID" & NewTestID & ") created from failed NGSTestID" & Me.NGSTestID & " (including testfiles)"
 updateNGSAnalysisLogEntrySQL = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
-      "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + updateNGSAnalysisLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
+                               "VALUES (" & CStr(Me![InternalPatientID]) & ",'" + updateNGSAnalysisLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 
 '  Deactivate failed test by settings NGSTest status to 'Test Failed' (1202218816)
 failNGSTestSQL = "UPDATE ngstest " & _
-         "SET statusid = 1202218816 " & _
-       "WHERE NGSTestID = " & Me.NGSTestID
+                 "   SET statusid = 1202218816 " & _
+                 " WHERE NGSTestID = " & Me.NGSTestID
 
 '  Update patient log to say test status set to failed
 failNGSTestLogEntry = "NGS: Status changed to ""test failed"" for NGSTestID" & Me.NGSTestID
 failNGSTestLogEntrySQL = "INSERT INTO patientlog(internalpatientid, logentry, [date], login, pcname) " & _
-      "VALUES (" + CStr(Me![InternalPatientID]) + ",'" + failNGSTestLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
+                         "VALUES (" + CStr(Me![InternalPatientID]) + ",'" + failNGSTestLogEntry + "',#" + date_now + "#,'" + UserName + "','" + computername + "')"
 
 ' Run SQL commands
 '   Turn off warnings so doesn't warn about appending rows


### PR DESCRIPTION
* Setting NGS Tests as failed or complete on the WES dashboard updates all NGSTests under the same NGSAnalysisGroup
* Replacing an NGS Test on the patient details page also updates the record for the NGSAnalysis
* The Exome Ordering form now displays patient names correctly when they contain commas

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/moka-fe/628)
<!-- Reviewable:end -->
