### PR TITLE
Fix non functioning error handling

### DIFF
--- a/forms/s87018_NGSTrioCoverage
+++ b/forms/s87018_NGSTrioCoverage
@@ -38,7 +38,7 @@ End Sub
 Private Sub coverage_button_Click()
     'button that updates subform datasheet with user specified results
     'if either textbox or combobox inputs are left empty, throw error message
-    If Me.gene_name_dropdown = "" Or Me.gene_name_dropdown = "Type or select gene name" Then
+    If IsNull(Me.gene_name_dropdown) Or Me.gene_name_dropdown = "Type or select gene name" Then
         MsgBox "Gene Name input required"
     Else
         'otherwise update subform with results corresponding to inputs


### PR DESCRIPTION
Update s87018_NGSTrioCoverage as error handling for a blank text box did not work at testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/moka-fe/636)
<!-- Reviewable:end -->
